### PR TITLE
ajout du cache flush pre updateschema pour le support des contentblocks

### DIFF
--- a/playbooks/typo3-deploy.yml
+++ b/playbooks/typo3-deploy.yml
@@ -131,6 +131,15 @@
         chdir: "{{ project_root }}"
       when: "'database:updateschema' in typo3_commands.stdout"
 
+    - name: TYPO3 cache flush pre database update
+      ansible.builtin.command: >
+        docker compose exec -T
+        -u www-data
+        -w /var/www
+        "{{ typo3_container }}" ./vendor/bin/typo3 cache:flush
+      args:
+        chdir: "{{ project_root }}"
+
     - name: TYPO3 database schema update via bin/typo3cms
       ansible.builtin.command: >
         docker compose exec -T


### PR DESCRIPTION
sinon on a une erreur du genre:
```
TASK [Composer repatch if composer patches are available] **********************
skipping: [ssm-target]

TASK [TYPO3 database schema update via bin/typo3] ******************************
fatal: [ssm-target]: FAILED! => {"changed": true, "cmd": ["docker", "compose", "exec", "-T", "-u", "www-data", "-w", "/var/www", "php-fpm", "./vendor/bin/typo3", "database:updateschema"], "delta": "0:00:03.017183", "end": "2026-06-10 15:15:05.982971", "msg": "non-zero return code", "rc": 1, "start": "2026-06-10 15:15:02.965788", "stderr": "\n                                                                    \n  [ Doctrine\\DBAL\\Platforms\\Exception\\NoColumnsSpecifiedForTable ]  \n  No columns specified for table \"toumoro_tilelist_tiles\".          \n                                                                    \n\ndatabase:updateschema [--dry-run] [--raw] [--] [<schemaUpdateTypes>]", "stderr_lines": ["", "                                                                    ", "  [ Doctrine\\DBAL\\Platforms\\Exception\\NoColumnsSpecifiedForTable ]  ", "  No columns specified for table \"toumoro_tilelist_tiles\".          ", "                                                                    ", "", "database:updateschema [--dry-run] [--raw] [--] [<schemaUpdateTypes>]"], "stdout": "", "stdout_lines": []}
